### PR TITLE
Update vagrant file for virtualbox

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -19,7 +19,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   
   
   config.vm.provider "vmware_fusion" do |v, override|
-    config.vm.box_url = "http://files.vagrantup.com/precise64_vmware.box"
+    override.vm.box_url = "http://files.vagrantup.com/precise64_vmware.box"
     v.name = HARVARD_CLASS_NAME
     v.gui = true
     v.vmx["memsize"] = "1024"


### PR DESCRIPTION
A call to : vagrant up --provider=virtualbox
download the http://files.vagrantup.com/precise64_vmware.box

Just changed variable "config" to "override" for the vmware_fusion box_url resolve this problem.