### PR TITLE
Add missing name attribute to the metadata.rb

### DIFF
--- a/cookbooks/sqlite-dev/metadata.rb
+++ b/cookbooks/sqlite-dev/metadata.rb
@@ -1,3 +1,4 @@
+name 		 "sqlite-dev"
 maintainer       "Pedro Axelrud"
 maintainer_email "pedroaxl@gmail.com"
 license          "MIT"


### PR DESCRIPTION
Fixes the first problem of https://github.com/rickfarmer/android-vm/issues/8